### PR TITLE
nest-asyncio 1.5.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nest-asyncio" %}
 {% set nameUnderscore = "nest_asyncio" %}
-{% set version = "1.5.5" %}
+{% set version = "1.5.6" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ nameUnderscore[0] }}/{{ nameUnderscore }}/{{ nameUnderscore }}-{{ version }}.tar.gz
-  sha256: e442291cd942698be619823a17a86a5759eabe1f8613084790de189fe9e16d65
+  sha256: d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290
 
 build:
   skip: True  # [py<35]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,14 @@ source:
 build:
   skip: True  # [py<35]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools >=42
-    - setuptools_scm >=3.4.3
+    - setuptools
+    - setuptools_scm
     - toml
     - wheel
   run:
@@ -29,6 +29,10 @@ requirements:
 test:
   imports:
     - nest_asyncio
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/erdewit/nest_asyncio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
     Trying to do so will give the error RuntimeError - This event loop is already running.
     The issue pops up in various environments, such as web servers, GUI applications and in Jupyter notebooks.
     This module patches asyncio to allow nested use of asyncio.run and loop.run_until_complete.
-  doc_url: https://github.com/erdewit/nest_asyncio
+  doc_url: https://github.com/erdewit/nest_asyncio/blob/master/README.rst
   dev_url: https://github.com/erdewit/nest_asyncio
 
 extra:


### PR DESCRIPTION
**Jira ticket:** [PKG-943](https://anaconda.atlassian.net/browse/PKG-943)

**The upstream data:**
Changes: https://github.com/erdewit/nest_asyncio/compare/v1.5.5...v1.5.6
License: https://github.com/erdewit/nest_asyncio/blob/v1.5.6/LICENSE
Requirements:
- https://github.com/erdewit/nest_asyncio/blob/v1.5.6/pyproject.toml
- setup.cfg https://github.com/erdewit/nest_asyncio/blob/v1.5.6/setup.cfg
- 


**_Actions:_**

- Add --no-deps flag to script

- Remove pinnings from host

- Add pip check


**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.5.6
 * Release on PyPi:
    * version: 1.5.6
    * date: 2022-09-30T07:09:16
* [PyPi history](https://pypi.org/project/nest-asyncio/#history)
 * Popularity: 
    * 3 months downloads: 1921677.0
    * All time:  7449551 downloads -  nest-asyncio  1.5.6  Patch asyncio to allow nested event loops  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/erdewit/nest_asyncio/tree/v1.5.6 exists
3. - [x] Check the pinnings    
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
    
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present

16. - [x] license_family BSD is present
17. - [x] License: BSD-2-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |
</details>

**Check dependency issues:**

<details>
../aggregate/nest-asyncio-feedstock/recipe/meta.yaml
Dependencies: ['setuptools >=42', 'wheel', 'toml', 'setuptools_scm >=3.4.3', 'pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/nest-asyncio-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/nest-asyncio-feedstock/tree/1.5.6)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/nest-asyncio)
* [Diff between upstream and feature branch](https://github.com/conda-forge/nest-asyncio-feedstock/compare/main...AnacondaRecipes:1.5.6)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/nest-asyncio-feedstock/compare/master...AnacondaRecipes:1.5.6)
* [The last merged PRs](https://github.com/AnacondaRecipes/nest-asyncio-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>


**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.5.6 git@github.com:AnacondaRecipes/nest-asyncio-feedstock.git
```
